### PR TITLE
Safe handling of special characters

### DIFF
--- a/views/partials/text.njk
+++ b/views/partials/text.njk
@@ -1,10 +1,10 @@
 {% if data.element.type == "show" %}
-  {{ data.element.title }}
+  {{ data.element.title | safe }}
   <tspan dx="7" style="font:600 22px monospace;fill:#f3f3f3;">
     {{ data.element.season }}x{{ data.element.episode }}
   </tspan>
-  {% if data.element.episode_title %}"{{ data.element.episode_title }}"{% endif %}
+  {% if data.element.episode_title %}"{{ data.element.episode_title | safe }}"{% endif %}
 {% elif data.element.type == "movie" %}
-  {{ data.element.title }}
+  {{ data.element.title | safe }}
   <tspan dx="7">{{ data.element.year }}</tspan>
 {% endif %}


### PR DESCRIPTION
The project is configured with `autoescape: true`, but in the case where it renders the SVG in `/views/partials/text.njk`, it needs the ` | safe` declaration added to the text in order to render special characters properly. You can see an example of this in the screenshots below:

Live deployment:
![image](https://github.com/user-attachments/assets/5ad1a0de-5110-43d8-94c6-eb59cce4e929)

This PR:
![image](https://github.com/user-attachments/assets/7e5ccdba-157c-4220-a12d-43c08a6bbb07)
